### PR TITLE
Support Connection Retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,6 +4478,7 @@ dependencies = [
  "rosetta-core",
  "surf",
  "tokio",
+ "tokio-retry",
 ]
 
 [[package]]
@@ -4498,6 +4499,7 @@ dependencies = [
  "sled",
  "tide",
  "tokio",
+ "tokio-retry",
  "vergen",
 ]
 
@@ -6421,6 +6423,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.23",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/rosetta-docker/Cargo.toml
+++ b/rosetta-docker/Cargo.toml
@@ -17,6 +17,7 @@ rosetta-client = { version = "0.4.0", path = "../rosetta-client" }
 rosetta-core = { version = "0.4.0", path = "../rosetta-core" }
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-no-tls"] }
 tokio = "1.26.0"
+tokio-retry = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros"] }

--- a/rosetta-docker/src/lib.rs
+++ b/rosetta-docker/src/lib.rs
@@ -338,6 +338,7 @@ async fn wait_for_http(url: &str, container: &Container) -> Result<()> {
                 }
             }
         },
+        // Retry Condition
         |error_message: &String| !error_message.starts_with("container exited"),
     )
     .await

--- a/rosetta-docker/src/lib.rs
+++ b/rosetta-docker/src/lib.rs
@@ -327,7 +327,7 @@ async fn wait_for_http(url: &str, container: &Container) -> Result<()> {
     RetryIf::spawn(
         retry_strategy,
         || async move {
-            match surf::get(&url).await {
+            match surf::get(url).await {
                 Ok(_) => Ok(()),
                 Err(err) => {
                     if health(container).await.is_err() {

--- a/rosetta-docker/src/lib.rs
+++ b/rosetta-docker/src/lib.rs
@@ -9,6 +9,10 @@ use futures::stream::StreamExt;
 use rosetta_client::{Client, Signer, Wallet};
 use rosetta_core::{BlockchainClient, BlockchainConfig};
 use std::time::Duration;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    RetryIf,
+};
 
 pub struct Env {
     config: BlockchainConfig,
@@ -31,8 +35,22 @@ impl Env {
         builder.stop_container(&builder.node_name(&config)).await?;
         builder.delete_network(&builder.network_name()).await?;
         let network = builder.create_network().await?;
-        let node = builder.run_node(&config, &network).await?;
-        let connector = builder.run_connector(&config, &network).await?;
+        let node = match builder.run_node(&config, &network).await {
+            Ok(node) => node,
+            Err(e) => {
+                network.delete().await?;
+                return Err(e);
+            }
+        };
+        let connector = match builder.run_connector(&config, &network).await {
+            Ok(connector) => connector,
+            Err(e) => {
+                let opts = ContainerStopOpts::builder().build();
+                let _ = node.stop(&opts).await;
+                network.delete().await?;
+                return Err(e);
+            }
+        };
         Ok(Self {
             config,
             network,
@@ -77,6 +95,7 @@ struct EnvBuilder<'a> {
 impl<'a> EnvBuilder<'a> {
     pub fn new(prefix: &'a str) -> Result<Self> {
         let version = ApiVersion::new(1, Some(41), None);
+        // TODO: Support custom connections #138
         #[cfg(unix)]
         let docker = Docker::unix_versioned("/var/run/docker.sock", version);
         #[cfg(not(unix))]
@@ -225,7 +244,7 @@ impl<'a> EnvBuilder<'a> {
             opts = opts.expose(PublishPort::tcp(port), port);
         }
         let container = self.run_container(name, &opts.build(), network).await?;
-        //wait_for_http(&format!("http://127.0.0.1:{}", config.node_port)).await?;
+        // wait_for_http(&format!("http://127.0.0.1:{}", config.node_port)).await?;
         tokio::time::sleep(Duration::from_secs(30)).await;
         Ok(container)
     }
@@ -239,7 +258,7 @@ impl<'a> EnvBuilder<'a> {
         let link = self.node_name(config);
         let opts = ContainerCreateOpts::builder()
             .name(&name)
-            .image(format!("analoglabs/connector-{}", config.blockchain))
+            .image(format!("analoglabs/connector-{}:latest", config.blockchain))
             .command(vec![
                 format!("--network={}", config.network),
                 format!("--addr=0.0.0.0:{}", config.connector_port),
@@ -255,8 +274,20 @@ impl<'a> EnvBuilder<'a> {
             )
             .build();
         let container = self.run_container(name, &opts, network).await?;
-        wait_for_http(&format!("http://127.0.0.1:{}", config.connector_port)).await?;
-        Ok(container)
+
+        match wait_for_http(
+            &format!("http://127.0.0.1:{}", config.connector_port),
+            &container,
+        )
+        .await
+        {
+            Ok(()) => Ok(container),
+            Err(err) => {
+                log::error!("connector failed to start: {}", err);
+                let _ = container.stop(&ContainerStopOpts::builder().build()).await;
+                Err(err)
+            }
+        }
     }
 }
 
@@ -286,17 +317,29 @@ async fn health(container: &Container) -> Result<Option<Health>> {
     }))
 }
 
-async fn wait_for_http(url: &str) -> Result<()> {
-    loop {
-        match surf::get(url).await {
-            Ok(_) => {
-                break;
+async fn wait_for_http(url: &str, container: &Container) -> Result<()> {
+    let retry_strategy = ExponentialBackoff::from_millis(2)
+        .factor(100)
+        .max_delay(Duration::from_secs(10))
+        .map(jitter) // add jitter to delays
+        .take(20); // limit to 20 retries
+
+    RetryIf::spawn(
+        retry_strategy,
+        || async move {
+            match surf::get(&url).await {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    if health(container).await.is_err() {
+                        return Err("container exited".to_string());
+                    }
+                    log::error!("url: {} error: {}", url, err);
+                    Err(err.to_string())
+                }
             }
-            Err(err) => {
-                log::error!("{}", err);
-                tokio::time::sleep(Duration::from_millis(500)).await;
-            }
-        }
-    }
-    Ok(())
+        },
+        |error_message: &String| !error_message.starts_with("container exited"),
+    )
+    .await
+    .map_err(|err| anyhow::format_err!("{}", err))
 }

--- a/rosetta-server/Cargo.toml
+++ b/rosetta-server/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.94"
 sled = "0.34.7"
 tide = { version = "0.16.0", default-features = false, features = ["h1-server", "logger"] }
 tokio = { version = "1.26.0", features = ["full"] }
+tokio-retry = "0.3"
 
 [build-dependencies]
 anyhow = "1.0.69"

--- a/rosetta-server/src/lib.rs
+++ b/rosetta-server/src/lib.rs
@@ -48,7 +48,6 @@ pub async fn main<T: BlockchainClient>() -> Result<()> {
 
     let client = {
         // TODO: Allow configuring the retry strategy and retry count
-        // Retry connecting to the node
         let retry_strategy = ExponentialBackoff::from_millis(2)
             .factor(100)
             .max_delay(Duration::from_secs(5))


### PR DESCRIPTION
## Description

This PR I introduce three changes
1. Limit the number of retries on `wait_for_http`, or abort when the container stops (before it was running forever)
2. Support connection retries on rosetta-server, in my machine the 30s fixed delay wasn't enough to accept connection (ex: polkadot), so I was getting inconsistent results locally.
3. Properly cleanup docker containers and network when some step fails

For the retries I'm using the **Exponential Backoff** strategy, which multiplicatively increase the delay of the retries, ex:
```rust
let mut s = ExponentialBackoff::from_millis(2).factor(100);

assert_eq!(s.next(), Some(Duration::from_millis(200)));
assert_eq!(s.next(), Some(Duration::from_millis(400)));
assert_eq!(s.next(), Some(Duration::from_millis(800)));
assert_eq!(s.next(), Some(Duration::from_millis(1600)));
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added
- [x] Dependent changes have been merged and published in downstream modules
