### PR TITLE
HOTFIX: Fix typo in push_connectors.sh

### DIFF
--- a/scripts/push_connectors.sh
+++ b/scripts/push_connectors.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # First arg is the Docker image tag on all images
 tag=$1
@@ -10,15 +11,15 @@ docker push analoglabs/connector-astar:latest
 
 if [[ -n "${tag}" ]]; then
     echo "Tagging all images: ${tag}";
-    docker tag analoglabs/connector-bitcoin "analoglabs/connector-bitcoin:${tag}"
+    docker tag analoglabs/connector-bitcoin:latest "analoglabs/connector-bitcoin:${tag}"
     docker push "analoglabs/connector-bitcoin:${tag}"
 
-    docker tag analoglabs/connector-ethereum "analoglabs/connector-ethereum:${tag}"
+    docker tag analoglabs/connector-ethereum:latest "analoglabs/connector-ethereum:${tag}"
     docker push "analoglabs/connector-ethereum:${tag}"
 
-    docker tag analoglabs/connector-polkadot "analoglabs/connector-polkadot:${tag}"
+    docker tag analoglabs/connector-polkadot:latest "analoglabs/connector-polkadot:${tag}"
     docker push "analoglabs/connector-polkadot:${tag}"
 
-    docker tag "analoglabs/connector-astar analoglabs/connector-astar:${tag}"
+    docker tag analoglabs/connector-astar:latest "analoglabs/connector-astar:${tag}"
     docker push "analoglabs/connector-astar:${tag}"
 fi


### PR DESCRIPTION
## Description

The command was failing to push the docker images due a typo introduced in this PR: https://github.com/Analog-Labs/chain-connectors/pull/157

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added
- [x] Dependent changes have been merged and published in downstream modules
