### PR TITLE
HOTFIX: Upgrade go-ethereum version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: stable
         components: rustfmt, clippy
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: stable
         components: clippy
@@ -73,7 +73,7 @@ jobs:
       run: sudo apt-get install -y musl-dev musl-tools solc
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: stable
         target: x86_64-unknown-linux-musl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         components: rustfmt, clippy
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         components: clippy
@@ -73,7 +73,7 @@ jobs:
       run: sudo apt-get install -y musl-dev musl-tools solc
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         target: x86_64-unknown-linux-musl

--- a/chains/ethereum/config/src/lib.rs
+++ b/chains/ethereum/config/src/lib.rs
@@ -20,7 +20,7 @@ pub fn config(network: &str) -> Result<BlockchainConfig> {
             currency_symbol: "ETH",
             currency_decimals: 18,
             node_uri: NodeUri::parse("http://127.0.0.1:8545")?,
-            node_image: "ethereum/client-go:v1.10.26",
+            node_image: "ethereum/client-go:v1.12.2",
             node_command: Arc::new(|network, port| {
                 let mut params = if network == "dev" {
                     vec![

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - "bitcoin-volume:/home/bitcoin/.bitcoin"
 
   ethereum:
-    image: "ethereum/client-go:v1.10.26"
+    image: "ethereum/client-go:v1.12.2"
     command: "--dev --ipcdisable --http --http.addr 0.0.0.0 --http.vhosts * --http.api eth,debug,admin,txpool,web3"
     expose:
     - "8545"

--- a/scripts/pull_nodes.sh
+++ b/scripts/pull_nodes.sh
@@ -2,6 +2,6 @@
 set -e
 
 docker image pull ruimarinho/bitcoin-core:23
-docker image pull ethereum/client-go:v1.10.26
+docker image pull ethereum/client-go:v1.12.2
 docker image pull parity/polkadot:v1.0.0
 docker image pull staketechnologies/astar-collator:v5.15.0


### PR DESCRIPTION
## Description

`ethereum/client-go:v1.10.2` doesn't support returning the finalized block, upgrading it to `ethereum/client-go:v1.12.2` for fix `/network/status` endpoint on local environment.

## Steps to Reproduce
Start a local node
```shell
docker run --rm -it -p 8545:8545 ethereum/client-go:v1.12.2 \
  --dev \
  --dev.period=2 \
  --ipcdisable \
  --http \
  --http.addr=0.0.0.0 \
  --http.port=8545 \
  --http.vhosts='*' \
  --http.api=eth,debug,admin,txpool,web3
```
Query the finalized block
```bash
curl -XPOST -H "Content-type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized", false], "id":1}' \
    'http://localhost:8545'
```

Using `ethereum/client-go:v1.10.26`  returns this:
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": null
}
```
Using `ethereum/client-go:v1.12.2` it works as expected:
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "baseFeePerGas": "0x22f06c09",
        ...
    }
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added
- [x] Dependent changes have been merged and published in downstream modules
