### PR TITLE
HOTFIX: Auto reconnect for websocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5053,6 +5053,7 @@ dependencies = [
  "ethabi",
  "ethers",
  "ethers-solc",
+ "futures-timer",
  "hex 0.4.3",
  "log",
  "pin-project",

--- a/chains/ethereum/server/Cargo.toml
+++ b/chains/ethereum/server/Cargo.toml
@@ -13,11 +13,12 @@ async-std = { version = "1.12", features = ["tokio1"] }
 async-trait = "0.1"
 ethabi = "18.0.0"
 ethers = { version = "2.0", default-features = true, features = ["ws", "abigen", "rustls"] }
+futures-timer = "3.0"
 hex = "0.4.3"
-rosetta-config-ethereum = { version = "0.4.0", path = "../config" }
-rosetta-server = { version = "0.4.0", path = "../../../rosetta-server" }
 log = "0.4"
 pin-project = "1.1"
+rosetta-config-ethereum = { version = "0.4.0", path = "../config" }
+rosetta-server = { version = "0.4.0", path = "../../../rosetta-server" }
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.32", features = ["rt-multi-thread", "macros"] }

--- a/chains/ethereum/server/src/client.rs
+++ b/chains/ethereum/server/src/client.rs
@@ -184,7 +184,13 @@ where
         let block = self
             .client
             .get_block_with_txs(block_id)
-            .await?
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "Failed to get block with transactions: {}",
+                    error.to_string()
+                )
+            })?
             .context("block not found")?;
         let block_number = block.number.context("Unable to fetch block number")?;
         let block_hash = block.hash.context("Unable to fetch block hash")?;

--- a/chains/ethereum/server/src/event_stream.rs
+++ b/chains/ethereum/server/src/event_stream.rs
@@ -48,13 +48,13 @@ where
                     let Some(number) = block.number else {
                         log::error!("block number is missing");
                         self.failures += 1;
-                        continue
+                        continue;
                     };
 
                     let Some(hash) = block.hash else {
                         log::error!("block hash is missing");
                         self.failures += 1;
-                        continue
+                        continue;
                     };
 
                     self.failures = 0;

--- a/chains/ethereum/server/src/ws_provider.rs
+++ b/chains/ethereum/server/src/ws_provider.rs
@@ -1,0 +1,140 @@
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use ethers::prelude::*;
+use ethers::providers::{ConnectionDetails, JsonRpcClient, PubsubClient, WsClientError};
+use futures_timer::Delay;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Websocket Provider that supports reconnecting
+#[derive(Debug)]
+pub struct ExtendedWs {
+    conn_details: ConnectionDetails,
+    client: ArcSwap<Ws>,
+    is_reconnecting: Arc<AtomicBool>,
+}
+
+impl ExtendedWs {
+    pub async fn connect(conn: impl Into<ConnectionDetails>) -> Result<Self, WsClientError> {
+        let conn_details = conn.into();
+        let client = Ws::connect(conn_details.clone()).await?;
+        Ok(Self {
+            conn_details,
+            client: ArcSwap::new(Arc::from(client)),
+            is_reconnecting: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    // TODO: reconnect in a different thread, otherwise the request will block
+    pub async fn reconnect(&self) -> Result<(), WsClientError> {
+        // Guarantee that only one thread is attempting to reconnect
+        if self.is_reconnecting.swap(true, Ordering::SeqCst) {
+            return Err(WsClientError::UnexpectedClose);
+        }
+
+        // Get the current client
+        let client = self.client.load();
+
+        // Check if is already connected
+        if is_connected(&client).await {
+            return Ok(());
+        }
+
+        // TODO: close the client after a given number of attempts
+        let mut attempts = 0;
+        loop {
+            attempts += 1;
+
+            log::info!("Retrying to connect... attempt {attempts}");
+            let client = Ws::connect(self.conn_details.clone()).await;
+
+            match client {
+                Ok(client) => {
+                    log::info!("Client reconnected successfully: {}", self.conn_details.url);
+                    self.client.store(Arc::from(client));
+                    break;
+                }
+                Err(e) => {
+                    log::error!("Failed to reconnect: {:?}", e);
+                }
+            };
+
+            Delay::new(Duration::from_secs(5)).await;
+        }
+        self.is_reconnecting.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl JsonRpcClient for ExtendedWs {
+    type Error = WsClientError;
+
+    async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
+    where
+        T: Debug + Serialize + Send + Sync,
+        R: DeserializeOwned + Send,
+    {
+        if self.is_reconnecting.load(Ordering::Relaxed) {
+            log::error!("Cannot process request, client is reconnecting: {method}");
+            return Err(WsClientError::UnexpectedClose);
+        }
+
+        let provider = self.client.load().clone();
+        let result = JsonRpcClient::request(&provider, method, params).await;
+
+        // Attempt to reconnect Connection unexpectedly closed
+        // TODO: execute this in a different thread/task, this will block the request
+        match result {
+            Err(WsClientError::UnexpectedClose) => {
+                log::error!("Websocket closed unexpectedly, reconnecting...");
+                self.reconnect().await?;
+                Err(WsClientError::UnexpectedClose)
+            }
+            Err(err) => {
+                // Log the error
+                log::error!("{err:?}");
+                Err(err)
+            }
+            _ => result,
+        }
+    }
+}
+
+impl PubsubClient for ExtendedWs {
+    type NotificationStream = <Ws as PubsubClient>::NotificationStream;
+
+    /// Add a subscription to this transport
+    fn subscribe<T: Into<U256>>(&self, id: T) -> Result<Self::NotificationStream, WsClientError> {
+        if self.is_reconnecting.load(Ordering::Relaxed) {
+            log::error!("subscription {} failed, client is reconnecting", id.into());
+            return Err(WsClientError::UnexpectedClose);
+        }
+
+        let client = self.client.load().clone();
+        PubsubClient::subscribe(client.as_ref(), id)
+    }
+
+    /// Remove a subscription from this transport
+    fn unsubscribe<T: Into<U256>>(&self, id: T) -> Result<(), Self::Error> {
+        if self.is_reconnecting.load(Ordering::Relaxed) {
+            log::error!("unsubscribe {} failed, client is reconnecting", id.into());
+            return Err(WsClientError::UnexpectedClose);
+        }
+
+        let client = self.client.load().clone();
+        PubsubClient::unsubscribe(client.as_ref(), id)
+    }
+}
+
+pub async fn is_connected(provider: &Ws) -> bool {
+    let result = JsonRpcClient::request::<_, U64>(provider, "eth_blockNumber", ()).await;
+    !matches!(
+        result,
+        Err(WsClientError::UnexpectedClose) | Err(WsClientError::InternalError(_))
+    )
+}

--- a/rosetta-core/Cargo.toml
+++ b/rosetta-core/Cargo.toml
@@ -10,9 +10,9 @@ description = "Provides traits and definitions shared by the server and client c
 anyhow = "1.0"
 async-trait = "0.1"
 fluent-uri = "0.1.4"
+futures-util = "0.3"
 rosetta-crypto = { version = "0.4.0", path = "../rosetta-crypto" }
 rosetta-types = { version = "0.4.0", path = "../rosetta-types" }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
-futures-util = "0.3"


### PR DESCRIPTION
## Description

The ethereum provider doesn't attempt to reconnect after disconnect, this PR adds a basic thread-safe reconnect logic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added
- [x] Dependent changes have been merged and published in downstream modules
