### PR TITLE
Refactor rosetta-client interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ca2c09d5911548a5cb620382ea0e1af99d3c898ce0efecbbd274a4676cf53e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bytes",
+ "smol_str",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40cea54ac58080a1b88ea6556866eac1902b321186c77d53ad2b5ebbbf0e038"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "indexmap 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81aa34725607be118c395d62c1d8d97c8a343dd1ada5370ed508ed5232eab6a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +259,130 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "array-bytes"
@@ -2206,6 +2391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.4",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "femme"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-num-traits"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "uint",
 ]
 
 [[package]]
@@ -4042,6 +4255,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "pest"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4510,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-num-traits",
  "impl-rlp",
  "impl-serde",
  "scale-info",
@@ -4356,6 +4581,8 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
@@ -4363,6 +4590,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.7.5",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -4374,6 +4603,12 @@ checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -4732,6 +4967,7 @@ dependencies = [
  "rosetta-tx-polkadot",
  "serde",
  "serde_json",
+ "void",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -4758,6 +4994,7 @@ name = "rosetta-config-ethereum"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "ethereum-types",
  "rosetta-config-astar",
  "rosetta-core",
  "serde",
@@ -4882,6 +5119,8 @@ dependencies = [
 name = "rosetta-server-astar"
 version = "0.5.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "ethers",
@@ -4919,12 +5158,15 @@ dependencies = [
  "rosetta-docker",
  "serde_json",
  "tokio",
+ "void",
 ]
 
 [[package]]
 name = "rosetta-server-ethereum"
 version = "0.5.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "ethabi",
@@ -5003,6 +5245,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
 name = "rust-bip39"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -5139,6 +5420,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -5472,7 +5765,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -5489,6 +5791,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -5787,6 +6098,15 @@ dependencies = [
  "async-process",
  "blocking",
  "futures-lite",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6698,6 +7018,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c7ad08db24862d5b787a94714ff6b047935c3e3f60af944ac969404debd7ff"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7257,6 +7589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7424,6 +7762,21 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/chains/astar/server/Cargo.toml
+++ b/chains/astar/server/Cargo.toml
@@ -27,6 +27,8 @@ subxt = { workspace = true, features = ["substrate-compat"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
+alloy-primitives = { version = "0.5" }
+alloy-sol-types = { version = "0.5" }
 ethers-solc = "2.0"
 rosetta-client.workspace = true
 rosetta-docker = { workspace = true, features = ["tests"] }

--- a/chains/astar/server/src/lib.rs
+++ b/chains/astar/server/src/lib.rs
@@ -5,22 +5,22 @@ use rosetta_config_astar::metadata::{
     dev as astar_metadata,
     dev::runtime_types::{frame_system::AccountInfo, pallet_balances::types::AccountData},
 };
-use rosetta_config_ethereum::{EthereumMetadata, EthereumMetadataParams};
+use rosetta_config_ethereum::{
+    EthereumMetadata, EthereumMetadataParams, Query as EthQuery, QueryResult as EthQueryResult,
+};
 use rosetta_core::{
     crypto::{
         address::{Address, AddressFormat},
         PublicKey,
     },
     types::{
-        Block, BlockIdentifier, CallRequest, Coin, PartialBlockIdentifier, Transaction,
-        TransactionIdentifier,
+        Block, BlockIdentifier, Coin, PartialBlockIdentifier, Transaction, TransactionIdentifier,
     },
     BlockchainClient, BlockchainConfig,
 };
 use rosetta_server::ws::default_client;
 use rosetta_server_ethereum::MaybeWsEthereumClient;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sp_core::crypto::Ss58AddressFormat;
 use std::sync::Arc;
 use subxt::{
@@ -124,6 +124,8 @@ impl BlockchainClient for AstarClient {
     type MetadataParams = AstarMetadataParams;
     type Metadata = AstarMetadata;
     type EventStream<'a> = <MaybeWsEthereumClient as BlockchainClient>::EventStream<'a>;
+    type Call = EthQuery;
+    type CallResult = EthQueryResult;
 
     fn config(&self) -> &BlockchainConfig {
         self.client.config()
@@ -221,7 +223,7 @@ impl BlockchainClient for AstarClient {
         self.client.block_transaction(block_identifier, tx).await
     }
 
-    async fn call(&self, req: &CallRequest) -> Result<Value> {
+    async fn call(&self, req: &EthQuery) -> Result<EthQueryResult> {
         self.client.call(req).await
     }
 
@@ -233,10 +235,20 @@ impl BlockchainClient for AstarClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_sol_types::{sol, SolCall};
     use ethers_solc::{artifacts::Source, CompilerInput, EvmVersion, Solc};
     use rosetta_docker::Env;
     use sha3::Digest;
     use std::{collections::BTreeMap, path::Path};
+
+    sol! {
+        interface TestContract {
+            event AnEvent();
+            function emitEvent() public {
+                emit AnEvent();
+            }
+        }
+    }
 
     pub async fn client_from_config(config: BlockchainConfig) -> Result<AstarClient> {
         let url = config.node_uri.to_string();
@@ -297,24 +309,25 @@ mod tests {
         wallet.faucet(faucet).await?;
 
         let bytes = compile_snippet(
-            r#"
+            r"
             event AnEvent();
             function emitEvent() public {
                 emit AnEvent();
             }
-        "#,
+            ",
         )?;
         let tx_hash = wallet.eth_deploy_contract(bytes).await?;
-
-        let receipt = wallet.eth_transaction_receipt(&tx_hash).await?;
-        let contract_address = receipt.get("contractAddress").and_then(Value::as_str).unwrap();
-        let tx_hash =
-            wallet.eth_send_call(contract_address, "function emitEvent()", &[], 0).await?;
-        let receipt = wallet.eth_transaction_receipt(&tx_hash).await?;
-        let logs = receipt.get("logs").and_then(Value::as_array).unwrap();
+        let receipt = wallet.eth_transaction_receipt(tx_hash).await?.unwrap();
+        let contract_address = receipt.contract_address.unwrap();
+        let tx_hash = {
+            let data = TestContract::emitEventCall::SELECTOR.to_vec();
+            wallet.eth_send_call(contract_address.0, data, 0).await?
+        };
+        let receipt = wallet.eth_transaction_receipt(tx_hash).await?;
+        let logs = receipt.logs;
         assert_eq!(logs.len(), 1);
-        let topic = logs[0]["topics"][0].as_str().unwrap();
-        let expected = format!("0x{}", hex::encode(sha3::Keccak256::digest("AnEvent()")));
+        let topic = logs[0].topics[0];
+        let expected = H256::from_slice(sha3::Keccak256::digest("AnEvent()").as_ref());
         assert_eq!(topic, expected);
         env.shutdown().await?;
         Ok(())
@@ -331,14 +344,14 @@ mod tests {
         wallet.faucet(faucet).await?;
 
         let bytes = compile_snippet(
-            r#"
+            r"
             function identity(bool a) public view returns (bool) {
                 return a;
             }
-        "#,
+        ",
         )?;
         let tx_hash = wallet.eth_deploy_contract(bytes).await?;
-        let receipt = wallet.eth_transaction_receipt(&tx_hash).await?;
+        let receipt = wallet.eth_transaction_receipt(tx_hash).await?;
         let contract_address = receipt["contractAddress"].as_str().unwrap();
 
         let response = wallet

--- a/chains/bitcoin/server/Cargo.toml
+++ b/chains/bitcoin/server/Cargo.toml
@@ -15,6 +15,7 @@ rosetta-config-bitcoin.workspace = true
 rosetta-core.workspace = true
 serde_json = "1.0"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+void = "1.0"
 
 [dev-dependencies]
 rosetta-docker = { workspace = true, features = ["tests"] }

--- a/chains/bitcoin/server/src/lib.rs
+++ b/chains/bitcoin/server/src/lib.rs
@@ -3,13 +3,12 @@ use bitcoincore_rpc_async::{bitcoin::BlockHash, Auth, Client, RpcApi};
 use rosetta_core::{
     crypto::{address::Address, PublicKey},
     types::{
-        Block, BlockIdentifier, CallRequest, Coin, PartialBlockIdentifier, Transaction,
-        TransactionIdentifier,
+        Block, BlockIdentifier, Coin, PartialBlockIdentifier, Transaction, TransactionIdentifier,
     },
     BlockchainClient, BlockchainConfig,
 };
-use serde_json::Value;
 use std::str::FromStr;
+use void::{unreachable, Void};
 
 pub type BitcoinMetadataParams = ();
 pub type BitcoinMetadata = ();
@@ -57,6 +56,8 @@ impl BlockchainClient for BitcoinClient {
     type MetadataParams = BitcoinMetadataParams;
     type Metadata = BitcoinMetadata;
     type EventStream<'a> = rosetta_core::EmptyEventStream;
+    type Call = Void;
+    type CallResult = ();
 
     fn config(&self) -> &BlockchainConfig {
         &self.config
@@ -170,8 +171,8 @@ impl BlockchainClient for BitcoinClient {
         anyhow::bail!("not implemented")
     }
 
-    async fn call(&self, _req: &CallRequest) -> Result<Value> {
-        anyhow::bail!("not implemented")
+    async fn call(&self, req: &Void) -> Result<()> {
+        unreachable(*req)
     }
 }
 

--- a/chains/ethereum/config/Cargo.toml
+++ b/chains/ethereum/config/Cargo.toml
@@ -8,6 +8,11 @@ description = "Ethereum configuration."
 
 [dependencies]
 anyhow = "1.0"
+ethereum-types = { version = "0.14", default-features = false, features = ["rlp", "ethbloom", "codec", "num-traits"] }
 rosetta-config-astar = { workspace = true }
 rosetta-core.workspace = true
 serde.workspace = true
+
+[features]
+default = ["std"]
+std = ["ethereum-types/std", "ethereum-types/serialize"]

--- a/chains/ethereum/config/src/lib.rs
+++ b/chains/ethereum/config/src/lib.rs
@@ -1,11 +1,15 @@
+mod types;
+
 use anyhow::Result;
+pub use ethereum_types;
+
 use rosetta_config_astar::config as astar_config;
 use rosetta_core::{
     crypto::{address::AddressFormat, Algorithm},
     BlockchainConfig, NodeUri,
 };
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+pub use types::*;
 
 /// Retrieve the [`BlockchainConfig`] from the provided polygon `network`
 ///
@@ -115,20 +119,4 @@ fn evm_config(
         connector_port: 8081,
         testnet: is_dev,
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct EthereumMetadataParams {
-    pub destination: Vec<u8>,
-    pub amount: [u64; 4],
-    pub data: Vec<u8>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct EthereumMetadata {
-    pub chain_id: u64,
-    pub nonce: u64,
-    pub max_priority_fee_per_gas: [u64; 4],
-    pub max_fee_per_gas: [u64; 4],
-    pub gas_limit: [u64; 4],
 }

--- a/chains/ethereum/config/src/types.rs
+++ b/chains/ethereum/config/src/types.rs
@@ -17,16 +17,12 @@ pub struct EthereumMetadata {
     pub gas_limit: [u64; 4],
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum AtBlock {
+    #[default]
+    Latest,
     Hash(H256),
     Number(u64),
-}
-
-impl Default for AtBlock {
-    fn default() -> Self {
-        Self::Number(0)
-    }
 }
 
 ///·Returns·the·balance·of·the·account·of·given·address.

--- a/chains/ethereum/config/src/types.rs
+++ b/chains/ethereum/config/src/types.rs
@@ -1,0 +1,240 @@
+use ethereum_types::{Address, Bloom, H256, U256};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EthereumMetadataParams {
+    pub destination: Vec<u8>,
+    pub amount: [u64; 4],
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EthereumMetadata {
+    pub chain_id: u64,
+    pub nonce: u64,
+    pub max_priority_fee_per_gas: [u64; 4],
+    pub max_fee_per_gas: [u64; 4],
+    pub gas_limit: [u64; 4],
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum AtBlock {
+    Hash(H256),
+    Number(u64),
+}
+
+impl Default for AtBlock {
+    fn default() -> Self {
+        Self::Number(0)
+    }
+}
+
+///·Returns·the·balance·of·the·account·of·given·address.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GetBalance {
+    /// Account address
+    pub address: Address,
+    /// Balance at the block
+    pub block: AtBlock,
+}
+
+/// Executes a new message call immediately without creating a transaction on the blockchain.
+#[derive(Clone, Default, PartialEq, Eq, Debug, Hash)]
+pub struct CallContract {
+    /// The address the transaction is sent from.
+    pub from: Option<Address>,
+    /// The address the transaction is directed to.
+    pub to: Address,
+    /// Integer of the value sent with this transaction.
+    pub value: U256,
+    /// Hash of the method signature and encoded parameters.
+    pub data: Vec<u8>,
+    /// Call at block
+    pub block: AtBlock,
+}
+
+/// Returns the account and storage values of the specified account including the Merkle-proof.
+/// This call can be used to verify that the data you are pulling from is not tampered with.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GetTransactionReceipt {
+    pub tx_hash: H256,
+}
+
+/// Returns the value from a storage position at a given address.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GetStorageAt {
+    /// Account address
+    pub address: Address,
+    /// integer of the position in the storage.
+    pub at: H256,
+    /// Storage at the block
+    pub block: AtBlock,
+}
+
+/// Returns the account and storage values, including the Merkle proof, of the specified
+/// account.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GetProof {
+    pub account: Address,
+    pub storage_keys: Vec<H256>,
+    pub block: AtBlock,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Query {
+    /// Returns the balance of the account of given address.
+    GetBalance(GetBalance),
+    /// Returns the value from a storage position at a given address.
+    GetStorageAt(GetStorageAt),
+    /// Returns the receipt of a transaction by transaction hash.
+    GetTransactionReceipt(GetTransactionReceipt),
+    /// Executes a new message call immediately without creating a transaction on the block
+    /// chain.
+    CallContract(CallContract),
+    /// Returns the account and storage values of the specified account including the
+    /// Merkle-proof. This call can be used to verify that the data you are pulling
+    /// from is not tampered with.
+    GetProof(GetProof),
+}
+
+/// The result of contract call execution
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CallResult {
+    /// Call executed succesfully
+    Success(Vec<u8>),
+    /// Call reverted with message
+    Revert(Vec<u8>),
+    /// normal EVM error.
+    Error,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryResult {
+    /// Returns the balance of the account of given address.
+    GetBalance(U256),
+    /// Returns the value from a storage position at a given address.
+    GetStorageAt(H256),
+    /// Returns the receipt of a transaction by transaction hash.
+    GetTransactionReceipt(Option<TransactionReceipt>),
+    /// Executes a new message call immediately without creating a transaction on the block
+    /// chain.
+    CallContract(CallResult),
+    /// Returns the account and storage values of the specified account including the
+    /// Merkle-proof. This call can be used to verify that the data you are pulling
+    /// from is not tampered with.
+    GetProof(EIP1186ProofResponse),
+}
+
+/// A log produced by a transaction.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct Log {
+    /// H160. the contract that emitted the log
+    pub address: Address,
+
+    /// topics: Array of 0 to 4 32 Bytes of indexed log arguments.
+    /// (In solidity: The first topic is the hash of the signature of the event
+    /// (e.g. `Deposit(address,bytes32,uint256)`), except you declared the event
+    /// with the anonymous specifier.)
+    pub topics: Vec<H256>,
+
+    /// Data
+    pub data: Vec<u8>,
+
+    /// Block Hash
+    pub block_hash: Option<H256>,
+
+    /// Block Number
+    pub block_number: Option<u64>,
+
+    /// Transaction Hash
+    pub transaction_hash: Option<H256>,
+
+    /// Transaction Index
+    pub transaction_index: Option<u64>,
+
+    /// Integer of the log index position in the block. None if it's a pending log.
+    pub log_index: Option<U256>,
+
+    /// Integer of the transactions index position log was created from.
+    /// None when it's a pending log.
+    pub transaction_log_index: Option<U256>,
+
+    /// Log Type
+    pub log_type: Option<String>,
+
+    /// True when the log was removed, due to a chain reorganization.
+    /// false if it's a valid log.
+    pub removed: Option<bool>,
+}
+
+/// "Receipt" of an executed transaction: details of its execution.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct TransactionReceipt {
+    /// Transaction hash.
+    pub transaction_hash: H256,
+
+    /// Index within the block.
+    pub transaction_index: u64,
+
+    /// Hash of the block this transaction was included within.
+    pub block_hash: Option<H256>,
+
+    /// Number of the block this transaction was included within.
+    pub block_number: Option<u64>,
+
+    /// address of the sender.
+    pub from: Address,
+
+    // address of the receiver. null when its a contract creation transaction.
+    pub to: Option<Address>,
+
+    /// Cumulative gas used within the block after this was executed.
+    pub cumulative_gas_used: U256,
+
+    /// Gas used by this transaction alone.
+    ///
+    /// Gas used is `None` if the the client is running in light client mode.
+    pub gas_used: Option<U256>,
+
+    /// Contract address created, or `None` if not a deployment.
+    pub contract_address: Option<Address>,
+
+    /// Logs generated within this transaction.
+    pub logs: Vec<Log>,
+
+    /// Status: either 1 (success) or 0 (failure). Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+    pub status_code: Option<u64>,
+
+    /// State root. Only present before activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+    pub state_root: Option<H256>,
+
+    /// Logs bloom
+    pub logs_bloom: Bloom,
+
+    /// The price paid post-execution by the transaction (i.e. base fee + priority fee).
+    /// Both fields in 1559-style transactions are *maximums* (max fee + max priority fee), the
+    /// amount that's actually paid by users can only be determined post-execution
+    pub effective_gas_price: Option<U256>,
+
+    /// EIP-2718 transaction type
+    pub transaction_type: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct StorageProof {
+    pub key: H256,
+    pub proof: Vec<Vec<u8>>,
+    pub value: U256,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct EIP1186ProofResponse {
+    pub address: Address,
+    pub balance: U256,
+    pub code_hash: H256,
+    pub nonce: u64,
+    pub storage_hash: H256,
+    pub account_proof: Vec<Vec<u8>>,
+    pub storage_proof: Vec<StorageProof>,
+}

--- a/chains/ethereum/server/Cargo.toml
+++ b/chains/ethereum/server/Cargo.toml
@@ -25,6 +25,8 @@ tracing = "0.1"
 url = "2.4"
 
 [dev-dependencies]
+alloy-primitives = { version = "0.5" }
+alloy-sol-types = { version = "0.5" }
 ethers-solc = "2.0"
 rosetta-client.workspace = true
 rosetta-docker = { workspace = true, features = ["tests"] }

--- a/chains/ethereum/server/src/client.rs
+++ b/chains/ethereum/server/src/client.rs
@@ -4,9 +4,7 @@ use crate::{
     utils::{get_non_pending_block, NonPendingBlock},
 };
 use anyhow::{Context, Result};
-// use ethabi::token::{LenientTokenizer, Tokenizer};
 use ethers::{
-    // abi::{Detokenize, HumanReadableParser InvalidOutputType, Token},
     prelude::*,
     providers::{JsonRpcClient, Middleware, Provider},
     types::Bytes,
@@ -25,16 +23,6 @@ use rosetta_core::{
     BlockchainConfig,
 };
 use std::{str::FromStr, sync::Arc};
-
-// struct Detokenizer {
-//     tokens: Vec<Token>,
-// }
-
-// impl Detokenize for Detokenizer {
-//     fn from_tokens(tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
-//         Ok(Self { tokens })
-//     }
-// }
 
 /// Strategy used to determine the finalized block
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
@@ -293,6 +281,7 @@ where
         let result = match req {
             EthQuery::GetBalance(GetBalance { address, block }) => {
                 let block_id = match *block {
+                    AtBlock::Latest => BlockId::Number(BlockNumber::Latest),
                     AtBlock::Number(number) => BlockId::Number(number.into()),
                     AtBlock::Hash(hash) => BlockId::Hash(hash),
                 };
@@ -301,6 +290,7 @@ where
             },
             EthQuery::GetStorageAt(GetStorageAt { address, at, block }) => {
                 let block_id = match *block {
+                    AtBlock::Latest => BlockId::Number(BlockNumber::Latest),
                     AtBlock::Number(number) => BlockId::Number(BlockNumber::Number(number.into())),
                     AtBlock::Hash(hash) => BlockId::Hash(hash),
                 };
@@ -347,6 +337,7 @@ where
             },
             EthQuery::CallContract(CallContract { from, to, data, value, block }) => {
                 let block_id = match *block {
+                    AtBlock::Latest => BlockId::Number(BlockNumber::Latest),
                     AtBlock::Number(number) => BlockId::Number(BlockNumber::Number(number.into())),
                     AtBlock::Hash(hash) => BlockId::Hash(hash),
                 };
@@ -363,6 +354,7 @@ where
             },
             EthQuery::GetProof(GetProof { account, storage_keys, block }) => {
                 let block_id = match *block {
+                    AtBlock::Latest => BlockId::Number(BlockNumber::Latest),
                     AtBlock::Number(number) => BlockId::Number(BlockNumber::Number(number.into())),
                     AtBlock::Hash(hash) => BlockId::Hash(hash),
                 };

--- a/chains/ethereum/tx/src/lib.rs
+++ b/chains/ethereum/tx/src/lib.rs
@@ -1,10 +1,6 @@
 use anyhow::Result;
-use ethabi::token::{LenientTokenizer, Tokenizer};
-use ethers_core::{
-    abi::HumanReadableParser,
-    types::{
-        transaction::eip2930::AccessList, Eip1559TransactionRequest, NameOrAddress, Signature, H160,
-    },
+use ethers_core::types::{
+    transaction::eip2930::AccessList, Eip1559TransactionRequest, NameOrAddress, Signature, H160,
 };
 use rosetta_config_ethereum::{EthereumMetadata, EthereumMetadataParams};
 use rosetta_core::{
@@ -34,23 +30,16 @@ impl TransactionBuilder for EthereumTransactionBuilder {
 
     fn method_call(
         &self,
-        contract: &str,
-        method: &str,
-        params: &[String],
+        contract: &[u8; 20],
+        data: &[u8],
         amount: u128,
     ) -> Result<Self::MetadataParams> {
-        let destination: H160 = contract.parse()?;
+        let destination = H160::from_slice(contract);
         let amount: U256 = amount.into();
-        let function = HumanReadableParser::parse_function(method)?;
-        let mut tokens = Vec::with_capacity(params.len());
-        for (ty, arg) in function.inputs.iter().zip(params) {
-            tokens.push(LenientTokenizer::tokenize(&ty.kind, arg)?);
-        }
-        let bytes = function.encode_input(&tokens)?;
         Ok(EthereumMetadataParams {
             destination: destination.0.to_vec(),
             amount: amount.0,
-            data: bytes,
+            data: data.to_vec(),
         })
     }
 

--- a/chains/polkadot/server/src/lib.rs
+++ b/chains/polkadot/server/src/lib.rs
@@ -113,6 +113,8 @@ impl BlockchainClient for PolkadotClient {
     type MetadataParams = PolkadotMetadataParams;
     type Metadata = PolkadotMetadata;
     type EventStream<'a> = EmptyEventStream;
+    type Call = CallRequest;
+    type CallResult = Value;
 
     fn config(&self) -> &BlockchainConfig {
         &self.config

--- a/chains/polkadot/tx/src/lib.rs
+++ b/chains/polkadot/tx/src/lib.rs
@@ -100,9 +100,8 @@ impl TransactionBuilder for PolkadotTransactionBuilder {
 
     fn method_call(
         &self,
-        _module: &str,
-        _method: &str,
-        _params: &[String],
+        _contract: &[u8; 20],
+        _data: &[u8],
         _amount: u128,
     ) -> Result<Self::MetadataParams> {
         bail!("Not Implemented")

--- a/rosetta-client/Cargo.toml
+++ b/rosetta-client/Cargo.toml
@@ -26,6 +26,7 @@ rosetta-tx-ethereum.workspace = true
 rosetta-tx-polkadot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+void = "1.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/rosetta-client/src/tx_builder.rs
+++ b/rosetta-client/src/tx_builder.rs
@@ -9,15 +9,16 @@ use rosetta_server_astar::AstarMetadataParams;
 
 pub enum GenericTransactionBuilder {
     Astar(rosetta_tx_ethereum::EthereumTransactionBuilder),
-    Ethereum(rosetta_tx_ethereum::EthereumTransactionBuilder),
+    // Ethereum(rosetta_tx_ethereum::EthereumTransactionBuilder),
     Polkadot(rosetta_tx_polkadot::PolkadotTransactionBuilder),
 }
 
 impl GenericTransactionBuilder {
     pub fn new(config: &BlockchainConfig) -> Result<Self> {
         Ok(match config.blockchain {
-            "astar" => Self::Astar(rosetta_tx_ethereum::EthereumTransactionBuilder),
-            "ethereum" => Self::Ethereum(rosetta_tx_ethereum::EthereumTransactionBuilder),
+            "astar" | "ethereum" | "polygon" | "arbitrum" => {
+                Self::Astar(rosetta_tx_ethereum::EthereumTransactionBuilder)
+            },
             "polkadot" => Self::Polkadot(rosetta_tx_polkadot::PolkadotTransactionBuilder),
             _ => anyhow::bail!("unsupported blockchain"),
         })
@@ -26,31 +27,28 @@ impl GenericTransactionBuilder {
     pub fn transfer(&self, address: &Address, amount: u128) -> Result<GenericMetadataParams> {
         Ok(match self {
             Self::Astar(tx) => AstarMetadataParams(tx.transfer(address, amount)?).into(),
-            Self::Ethereum(tx) => tx.transfer(address, amount)?.into(),
+            // Self::Ethereum(tx) => tx.transfer(address, amount)?.into(),
             Self::Polkadot(tx) => tx.transfer(address, amount)?.into(),
         })
     }
 
     pub fn method_call(
         &self,
-        contract: &str,
-        method: &str,
-        params: &[String],
+        contract: &[u8; 20],
+        data: &[u8],
         amount: u128,
     ) -> Result<GenericMetadataParams> {
         Ok(match self {
-            Self::Astar(tx) => {
-                AstarMetadataParams(tx.method_call(contract, method, params, amount)?).into()
-            },
-            Self::Ethereum(tx) => tx.method_call(contract, method, params, amount)?.into(),
-            Self::Polkadot(tx) => tx.method_call(contract, method, params, amount)?.into(),
+            Self::Astar(tx) => AstarMetadataParams(tx.method_call(contract, data, amount)?).into(),
+            // Self::Ethereum(tx) => tx.method_call(contract, data, amount)?.into(),
+            Self::Polkadot(tx) => tx.method_call(contract, data, amount)?.into(),
         })
     }
 
     pub fn deploy_contract(&self, contract_binary: Vec<u8>) -> Result<GenericMetadataParams> {
         Ok(match self {
             Self::Astar(tx) => AstarMetadataParams(tx.deploy_contract(contract_binary)?).into(),
-            Self::Ethereum(tx) => tx.deploy_contract(contract_binary)?.into(),
+            // Self::Ethereum(tx) => tx.deploy_contract(contract_binary)?.into(),
             Self::Polkadot(tx) => tx.deploy_contract(contract_binary)?.into(),
         })
     }
@@ -68,11 +66,11 @@ impl GenericTransactionBuilder {
                 GenericMetadataParams::Astar(params),
                 GenericMetadata::Astar(metadata),
             ) => tx.create_and_sign(config, &params.0, &metadata.0, secret_key),
-            (
-                Self::Ethereum(tx),
-                GenericMetadataParams::Ethereum(params),
-                GenericMetadata::Ethereum(metadata),
-            ) => tx.create_and_sign(config, params, metadata, secret_key),
+            // (
+            //     Self::Ethereum(tx),
+            //     GenericMetadataParams::Ethereum(params),
+            //     GenericMetadata::Ethereum(metadata),
+            // ) => tx.create_and_sign(config, params, metadata, secret_key),
             (
                 Self::Polkadot(tx),
                 GenericMetadataParams::Polkadot(params),

--- a/rosetta-client/src/wallet.rs
+++ b/rosetta-client/src/wallet.rs
@@ -144,25 +144,6 @@ impl Wallet {
         self.client.block_transaction(&block_identifer, &tx_identifier).await
     }
 
-    // /// Extension of rosetta-api does multiple things
-    // /// 1. fetching storage
-    // /// 2. calling extrinsic/contract
-    // #[allow(clippy::missing_errors_doc)]
-    // async fn call(
-    //     &self,
-    //     method: String,
-    //     params: &serde_json::Value,
-    //     block_identifier: Option<PartialBlockIdentifier>,
-    // ) -> Result<serde_json::Value> {
-    //     let req = CallRequest {
-    //         network_identifier: self.client.config().network(),
-    //         method,
-    //         parameters: params.clone(),
-    //         block_identifier,
-    //     };
-    //     self.client.call(&req).await
-    // }
-
     /// Returns the coins of the wallet.
     #[allow(clippy::missing_errors_doc)]
     pub async fn coins(&self) -> Result<Vec<Coin>> {
@@ -299,8 +280,6 @@ impl Wallet {
             anyhow::bail!("[this is a bug] invalid result type");
         };
         Ok(exit_reason)
-        // let method = format!("{contract_address}-{method_signature}-call");
-        // self.call(method, &json!(params), block_identifier).await
     }
 
     /// gets storage from ethereum contract
@@ -329,8 +308,6 @@ impl Wallet {
             anyhow::bail!("[this is a bug] invalid result type");
         };
         Ok(value)
-        // let method = format!("{contract_address}-{storage_slot}-storage");
-        // self.call(method, &json!({}), block_identifier).await
     }
 
     /// gets storage proof from ethereum contract
@@ -358,8 +335,6 @@ impl Wallet {
             anyhow::bail!("[this is a bug] invalid result type");
         };
         Ok(proof)
-        // let method = format!("{contract_address}-{storage_slot}-storage_proof");
-        // self.call(method, &json!({}), block_identifier).await
     }
 
     /// gets transaction receipt of specific hash
@@ -384,7 +359,5 @@ impl Wallet {
             anyhow::bail!("[this is a bug] invalid result type");
         };
         Ok(maybe_receipt)
-        // let call_method = format!("{}--transaction_receipt", hex::encode(tx_hash));
-        // self.call(call_method, &json!({}), None).await
     }
 }

--- a/rosetta-server/src/ws/reconnect_impl.rs
+++ b/rosetta-server/src/ws/reconnect_impl.rs
@@ -217,34 +217,27 @@ impl<T: Config> Future for ReadyOrWaitFuture<T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        loop {
-            match this.state.take() {
-                Some(ReadyOrWaitState::Ready(result)) => return Poll::Ready(result),
-                Some(ReadyOrWaitState::Waiting(mut future)) => {
-                    match future.poll_unpin(cx) {
-                        // The request delay timeout
-                        Poll::Ready(Either::Left(_)) => {
-                            return Poll::Ready(Err(Error::Custom(
-                                "Timeout: cannot process request, client reconnecting..."
-                                    .to_string(),
-                            )))
-                        },
-                        // The client was reconnected!
-                        Poll::Ready(Either::Right((Ok(client), _))) => {
-                            return Poll::Ready(Ok(client))
-                        },
-                        // Failed to reconnect
-                        Poll::Ready(Either::Right((Err(result), _))) => {
-                            return Poll::Ready(Err(result.into_inner()))
-                        },
-                        Poll::Pending => {
-                            *this.state = Some(ReadyOrWaitState::Waiting(future));
-                            return Poll::Pending;
-                        },
-                    }
-                },
-                None => panic!("ClientReadyFuture polled after completion"),
-            }
+        match this.state.take() {
+            Some(ReadyOrWaitState::Ready(result)) => Poll::Ready(result),
+            Some(ReadyOrWaitState::Waiting(mut future)) => {
+                match future.poll_unpin(cx) {
+                    // The request delay timeout
+                    Poll::Ready(Either::Left(_)) => Poll::Ready(Err(Error::Custom(
+                        "Timeout: cannot process request, client reconnecting...".to_string(),
+                    ))),
+                    // The client was reconnected!
+                    Poll::Ready(Either::Right((Ok(client), _))) => Poll::Ready(Ok(client)),
+                    // Failed to reconnect
+                    Poll::Ready(Either::Right((Err(result), _))) => {
+                        Poll::Ready(Err(result.into_inner()))
+                    },
+                    Poll::Pending => {
+                        *this.state = Some(ReadyOrWaitState::Waiting(future));
+                        Poll::Pending
+                    },
+                }
+            },
+            None => panic!("ClientReadyFuture polled after completion"),
         }
     }
 }


### PR DESCRIPTION
## Description

Removes `method` and `function_selector` from rosetta-client interfaces, also accept raw bytes instead of string as parameter.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
