### PR TITLE
#223 - Remove the generic block identifier

### DIFF
--- a/chains/astar/server/src/lib.rs
+++ b/chains/astar/server/src/lib.rs
@@ -461,7 +461,6 @@ mod tests {
     #[tokio::test]
     async fn test_subscription() -> Result<()> {
         use futures_util::StreamExt;
-        use rosetta_client::client::GenericBlockIdentifier;
         use rosetta_core::{BlockOrIdentifier, ClientEvent};
         let config = rosetta_config_astar::config("dev").unwrap();
         let env = Env::new("astar-subscription", config.clone(), client_from_config)
@@ -477,17 +476,13 @@ mod tests {
             for _ in 0..10 {
                 let event = stream.next().await.unwrap();
                 match event {
-                    ClientEvent::NewHead(BlockOrIdentifier::Identifier(
-                        GenericBlockIdentifier::Ethereum(head),
-                    )) => {
+                    ClientEvent::NewHead(BlockOrIdentifier::Identifier(head)) => {
                         if let Some(block_number) = last_head {
                             assert!(head.index > block_number);
                         }
                         last_head = Some(head.index);
                     },
-                    ClientEvent::NewFinalized(BlockOrIdentifier::Identifier(
-                        GenericBlockIdentifier::Ethereum(finalized),
-                    )) => {
+                    ClientEvent::NewFinalized(BlockOrIdentifier::Identifier(finalized)) => {
                         if let Some(block_number) = last_finalized {
                             assert!(finalized.index > block_number);
                         }

--- a/chains/ethereum/server/src/lib.rs
+++ b/chains/ethereum/server/src/lib.rs
@@ -387,7 +387,6 @@ mod tests {
     #[tokio::test]
     async fn test_subscription() -> Result<()> {
         use futures_util::StreamExt;
-        use rosetta_client::client::GenericBlockIdentifier;
         use rosetta_core::{BlockOrIdentifier, ClientEvent};
         let config = rosetta_config_ethereum::config("dev").unwrap();
         let env = Env::new("ethereum-subscription", config.clone(), client_from_config)
@@ -403,17 +402,13 @@ mod tests {
             for _ in 0..10 {
                 let event = stream.next().await.unwrap();
                 match event {
-                    ClientEvent::NewHead(BlockOrIdentifier::Identifier(
-                        GenericBlockIdentifier::Ethereum(head),
-                    )) => {
+                    ClientEvent::NewHead(BlockOrIdentifier::Identifier(head)) => {
                         if let Some(block_number) = last_head {
                             assert!(head.index > block_number);
                         }
                         last_head = Some(head.index);
                     },
-                    ClientEvent::NewFinalized(BlockOrIdentifier::Identifier(
-                        GenericBlockIdentifier::Ethereum(finalized),
-                    )) => {
+                    ClientEvent::NewFinalized(BlockOrIdentifier::Identifier(finalized)) => {
                         if let Some(block_number) = last_finalized {
                             assert!(finalized.index > block_number);
                         }

--- a/rosetta-client/src/wallet.rs
+++ b/rosetta-client/src/wallet.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client::{GenericBlockIdentifier, GenericClient, GenericMetadata, GenericMetadataParams},
+    client::{GenericClient, GenericMetadata, GenericMetadataParams},
     crypto::{address::Address, bip32::DerivedSecretKey, bip44::ChildNumber},
     mnemonic::MnemonicStore,
     signer::{RosettaAccount, RosettaPublicKey, Signer},
@@ -113,29 +113,14 @@ impl Wallet {
         let address =
             Address::new(self.client.config().address_format, self.account.address.clone());
         let balance = match &self.client {
-            GenericClient::Astar(client) => match block {
-                GenericBlockIdentifier::Ethereum(block) => {
-                    client.balance(&address, &PartialBlockIdentifier::from(block)).await?
-                },
-                GenericBlockIdentifier::Polkadot(_) => {
-                    anyhow::bail!("[this is bug] client returned an invalid block identifier")
-                },
+            GenericClient::Astar(client) => {
+                client.balance(&address, &PartialBlockIdentifier::from(block)).await?
             },
-            GenericClient::Ethereum(client) => match block {
-                GenericBlockIdentifier::Ethereum(block) => {
-                    client.balance(&address, &PartialBlockIdentifier::from(block)).await?
-                },
-                GenericBlockIdentifier::Polkadot(_) => {
-                    anyhow::bail!("[this is bug] client returned an invalid block identifier")
-                },
+            GenericClient::Ethereum(client) => {
+                client.balance(&address, &PartialBlockIdentifier::from(block)).await?
             },
-            GenericClient::Polkadot(client) => match block {
-                GenericBlockIdentifier::Polkadot(block) => {
-                    client.balance(&address, &PartialBlockIdentifier::from(block)).await?
-                },
-                GenericBlockIdentifier::Ethereum(_) => {
-                    anyhow::bail!("[this is bug] client returned an invalid block identifier")
-                },
+            GenericClient::Polkadot(client) => {
+                client.balance(&address, &PartialBlockIdentifier::from(block)).await?
             },
         };
         Ok(balance)

--- a/rosetta-core/src/types.rs
+++ b/rosetta-core/src/types.rs
@@ -65,6 +65,24 @@ pub struct PartialBlockIdentifier {
     pub hash: Option<[u8; 32]>,
 }
 
+impl From<u64> for PartialBlockIdentifier {
+    fn from(block_number: u64) -> Self {
+        Self { index: Some(block_number), hash: None }
+    }
+}
+
+impl From<[u8; 32]> for PartialBlockIdentifier {
+    fn from(block_hash: [u8; 32]) -> Self {
+        Self { index: None, hash: Some(block_hash) }
+    }
+}
+
+impl From<&[u8; 32]> for PartialBlockIdentifier {
+    fn from(block_hash: &[u8; 32]) -> Self {
+        Self { index: None, hash: Some(*block_hash) }
+    }
+}
+
 impl From<BlockIdentifier> for PartialBlockIdentifier {
     fn from(block_identifier: BlockIdentifier) -> Self {
         Self { index: Some(block_identifier.index), hash: Some(block_identifier.hash) }


### PR DESCRIPTION
## Description

Removes the GenericBlockIdentifier, and is not required to expose it to the wallet api.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)