### PR TITLE
Add nonce in tx after estimating gas

### DIFF
--- a/chains/ethereum/server/src/client.rs
+++ b/chains/ethereum/server/src/client.rs
@@ -304,14 +304,14 @@ where
         } else {
             self.backend.get_transaction_count(from, AtBlock::Latest).await?
         };
-        let tx = CallRequest {
+        let mut tx = CallRequest {
             from: Some(from),
             to,
             gas_limit: None,
             gas_price: None,
             value: Some(U256(options.amount)),
             data: Some(options.data.clone().into()),
-            nonce: Some(nonce),
+            nonce: None,
             chain_id: None, // Astar doesn't support this field for eth_call
             max_priority_fee_per_gas: Some(max_priority_fee_per_gas),
             access_list: AccessList::default(),
@@ -324,6 +324,8 @@ where
             let gas_limit = self.backend.estimate_gas(&tx, AtBlock::Latest).await?;
             u64::try_from(gas_limit).unwrap_or(u64::MAX)
         };
+
+        tx.nonce = Some(nonce);
 
         Ok(EthereumMetadata {
             chain_id,


### PR DESCRIPTION
## Description

Computes estimated gas without nonce and adds nonce to transaction after gas is computed.

Fixes # (issue)
#240 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added
- [x] Dependent changes have been merged and published in downstream modules
