### PR TITLE
#237 Fix ethereum-based chains testnet public keys

### DIFF
--- a/chains/astar/config/src/lib.rs
+++ b/chains/astar/config/src/lib.rs
@@ -44,7 +44,7 @@ pub fn config(network: &str) -> Result<BlockchainConfig> {
         network,
         algorithm: Algorithm::EcdsaRecoverableSecp256k1,
         address_format: AddressFormat::Eip55,
-        coin: if network == "astar" { 810 } else { 1 },
+        coin: if network == "astar" { 810 } else { 60 },
         bip44: true,
         utxo: false,
         currency_unit: "planck",

--- a/chains/ethereum/config/src/lib.rs
+++ b/chains/ethereum/config/src/lib.rs
@@ -210,8 +210,8 @@ impl rosetta_core::traits::Block for BlockFull {
 pub fn polygon_config(network: &str) -> anyhow::Result<BlockchainConfig> {
     let (network, bip44_id, is_dev) = match network {
         "dev" => ("dev", 1, true),
-        "mumbai" => ("mumbai", 80001, true),
-        "amoy" => ("amoy", 80002, true),
+        "mumbai" => ("mumbai", 60, true),
+        "amoy" => ("amoy", 60, true),
         "mainnet" => ("mainnet", 966, false),
         _ => anyhow::bail!("unsupported network: {}", network),
     };
@@ -226,7 +226,7 @@ pub fn arbitrum_config(network: &str) -> anyhow::Result<BlockchainConfig> {
     // All available networks are listed here:
     let (network, bip44_id, is_dev) = match network {
         "dev" => ("dev", 1, true),
-        "goerli" => ("goerli", 1, true),
+        "goerli" => ("goerli", 60, true),
         "mainnet" => ("mainnet", 42161, false),
         _ => anyhow::bail!("unsupported network: {}", network),
     };
@@ -241,8 +241,8 @@ pub fn config(network: &str) -> anyhow::Result<BlockchainConfig> {
     let (network, symbol, bip44_id, is_dev) = match network {
         "dev" => ("dev", "ETH", 1, true),
         "mainnet" => ("mainnet", "ETH", 60, false),
-        "goerli" => ("goerli", "TST", 1, true),
-        "sepolia" => ("sepolia", "SepoliaETH", 1, true),
+        "goerli" => ("goerli", "TST", 60, true),
+        "sepolia" => ("sepolia", "SepoliaETH", 60, true),
 
         // Polygon
         "polygon-local" => return polygon_config("dev"),


### PR DESCRIPTION
## Description

This PR fixes ethereum based chains testnet public keys which are different then what public wallet shows.
It changes coin ids from 1 to 60 for current ethereum based supported testnets by chain-connectors.


Fixes # (issue)
https://github.com/Analog-Labs/chain-connectors/issues/237

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Imported crate and verified a mnemonic's public key with public key of metamask

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
