### PR TITLE
block_stream: remove state handling for orphaned blocks

### DIFF
--- a/chains/ethereum/server/src/block_stream.rs
+++ b/chains/ethereum/server/src/block_stream.rs
@@ -78,15 +78,6 @@ where
                         })
                     };
                     let is_finalized = matches!(new_block, NewBlock::Finalized(_));
-                    // if let Err(err) = self.state.import(new_block.into_sealed_block()) {
-                    //     failures += 1;
-                    //     tracing::warn!("failed to import block {block_id} ({failures}): {err:?}");
-                    //     if failures >= 5 {
-                    //         return Poll::Ready(None);
-                    //     }
-                    //     continue;
-                    // }
-
                     let event = if is_finalized {
                         ClientEvent::NewFinalized(block_id)
                     } else {

--- a/chains/ethereum/server/src/block_stream.rs
+++ b/chains/ethereum/server/src/block_stream.rs
@@ -78,14 +78,14 @@ where
                         })
                     };
                     let is_finalized = matches!(new_block, NewBlock::Finalized(_));
-                    if let Err(err) = self.state.import(new_block.into_sealed_block()) {
-                        failures += 1;
-                        tracing::warn!("failed to import block {block_id} ({failures}): {err:?}");
-                        if failures >= 5 {
-                            return Poll::Ready(None);
-                        }
-                        continue;
-                    }
+                    // if let Err(err) = self.state.import(new_block.into_sealed_block()) {
+                    //     failures += 1;
+                    //     tracing::warn!("failed to import block {block_id} ({failures}): {err:?}");
+                    //     if failures >= 5 {
+                    //         return Poll::Ready(None);
+                    //     }
+                    //     continue;
+                    // }
 
                     let event = if is_finalized {
                         ClientEvent::NewFinalized(block_id)

--- a/chains/ethereum/server/src/state.rs
+++ b/chains/ethereum/server/src/state.rs
@@ -265,6 +265,7 @@ impl StateInner {
 
         // Add finalized block to the list
         self.finalized_blocks.push_back(finalized_block_ref);
+        let _ = self.finalized_blocks.pop_front();
 
         // Remove retracted blocks
         let finalized_blocks = &self.finalized_blocks;


### PR DESCRIPTION
## Description

This PR removes the internal `BlockStream` state management and re-balancing of the orphaned blocks. The reason for this change is because it turns out that the internals cause a memory leak (or better to say memory misuse) described in [THIS](https://github.com/Analog-Labs/timechain/issues/1309) issue.

## Test

I've updated the chronicle to point to the last commit of this branch and run it on integration environment for 3 days, here are the results:
![image](https://github.com/user-attachments/assets/9ebf68d9-4dcd-4228-9dc3-eaea41bb0b2e)

The updated 3 chronicles use a stable 30MB during the period of testing, while the old ones are taking up the whole node (3-4GB).

## Additional Information

Because I'm not familiar with this part and I haven't tested ALL cases of a shard working with this change, @Lohann can you point out what this code does and what are the implications of removing it?